### PR TITLE
JWT token send and save to cookies when logged in. JWTFilter changed …

### DIFF
--- a/backend/src/main/java/com/matchme/controller/UserController.java
+++ b/backend/src/main/java/com/matchme/controller/UserController.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/users")
-@CrossOrigin(origins = "*")
+@CrossOrigin(origins = "http://localhost:3000", allowCredentials = "true")
 public class UserController {
 
     @Autowired

--- a/backend/src/main/java/com/matchme/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/matchme/security/JwtAuthenticationFilter.java
@@ -40,8 +40,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String email = null;
         String jwt = null;
 
+        //if we have  auth Header
         if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
             jwt = authorizationHeader.substring(7);
+        }else if(request.getCookies() != null){
+            for (jakarta.servlet.http.Cookie cookie : request.getCookies()) {
+            if ("jwt".equals(cookie.getName())) {
+                jwt = cookie.getValue();
+            break;
+            }   
+        }
+    }
+                //if we have JWT, take email out
+        if(jwt != null){   
             try {
                 email = jwtUtil.extractUsername(jwt);
             } catch (Exception e) {

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,73 +1,50 @@
-# React + TypeScript + Vite
+# Match-Me Web (Frontend)
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+## Tech Stack (Frontend)
+- React -v 19.1.1
+- React-dom -v 19.1.1 
+- Rreact-router-dom -v 7.9.3
+- Vite -v 7.1.7
+- Typescript -v 5.8.3
 
-Currently, two official plugins are available:
+## Features
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+# Authentication
+- Users log in with email and password.
+- JWT tokens are stored in cookies and used for authenticated requests.
+- Logout clears session cookie and frontend state.
 
-## React Compiler
+# User Profile
+- Users must complete their profile to receive recommendations.
+- Profile includes username, preferred servers, games, gaming experience, gaming hours, “About me” section.
+- Users can upload/remove profile pictures.
+- Profile info is editable at any time.
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
 
-## Expanding the ESLint configuration
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
 
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
+## Running the Frontend
 
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+Clone the repository
+```bash
+git clone https://github.com/erikmartinmerisalu/match-me
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Navigate to front end
+```bash
+cd .\match-me\frontend\
+```
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+Start the development server
+```bash
+npm run dev
+```
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+The server starts at localhost port 5173 and you should see:
+```bash
+  VITE v7.1.7  ready in 0 ms
+
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose
+  ➜  press h + enter to show help
 ```

--- a/frontend/src/auth/LogIn.tsx
+++ b/frontend/src/auth/LogIn.tsx
@@ -34,8 +34,6 @@ function LogIn() {
       }
 
       const data = await response.json();
-
-
       
       navigate("/userprofile");
       setLoggedIn(true);

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,42 +1,55 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import type { ReactNode} from "react";
 
+//React Context --> Auth context is for providing login boolean state over the application. If user or app refreshes,
+// then we need to fetch and check if the cookie is still valid, because context loses all of the values after refresh
+
+//decleare the types
 type AuthContextType = {
     loggedIn : boolean | null,
     setLoggedIn: (value : boolean) =>void ;
     signOut : () => void;
   }
 
+
+
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
+//types for what we expect as output
 type AuthProviderProps = {
   children: ReactNode;
 };
 
+
+// This is the Provider component that holds the state and provides it to children
 export const AuthContextProvider = ({children } : AuthProviderProps) => {
     const [loggedIn, setLoggedIn] = useState<boolean | null >(false);
 
-
+// useEffect runs on component mount to check if the user session is valid
+// Fetches /api/users/me which returns user info if logged in (cookie/session is valid)
   useEffect(() => {
-    const token = sessionStorage.getItem("token");
-
-    if (token) {
-        fetch("/api/me", {
+        fetch("http://localhost:8080/api/users/me", {
+        method: "GET",
         headers: {
-            Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
         },
+        //cookies are included
+        credentials: "include"
         })
         .then((res) => {
             if (!res.ok) throw new Error("unauthorized");
+            //if res is ok, then set login true
             setLoggedIn(true);
+            console.log(res);
         })
         .catch(() => {
             setLoggedIn(false);
-            sessionStorage.removeItem("token");
         });
-    }
-    }, []);
+    },[]);
 
+    // Function to log out the user
+    // Sends POST to backend to clear session/cookie
+    // Then updates local state
     const signOut = async () => {
       await fetch("http://localhost:8080/api/auth/logout", {
         method: "POST",
@@ -45,7 +58,7 @@ export const AuthContextProvider = ({children } : AuthProviderProps) => {
       setLoggedIn(false);
     }
 
-
+    // Provide the state and functions to all children components
     return(
         <AuthContext.Provider value={{loggedIn, setLoggedIn, signOut}}>
             {children}
@@ -53,7 +66,7 @@ export const AuthContextProvider = ({children } : AuthProviderProps) => {
     )
 }
 
-
+// Custom hook to use AuthContext easily in other components/pages
 export const useAuth = () => {
   const ctx = useContext(AuthContext);
   if (!ctx) {

--- a/frontend/src/pages/userprofile/UserProfile.tsx
+++ b/frontend/src/pages/userprofile/UserProfile.tsx
@@ -4,39 +4,44 @@ import  {  ChangeEvent } from "react";
 import "./userprofile.css";
 
 const UserProfile: React.FC = () => {
-  const platformOptions = ["PC", "PlayStation", "Xbox", "Nintendo Switch", "Mobile"]
-  const playStyleOptions = ["Casual", "Competitive", "Hardcore", "Speedrun"]
-  const genreOptions = ["Action", "Action-adventure", "Adventure", "Puzzle", "Simulation", "Strategy", "Sports", "Role-playing"]
+  const serverOptions = ["N-America", "S-America", "EU East", "EU West", "Asia", "AU+SEA", "Africa+Middle east"]
+  const gameOptions = ["Game1", "Game2", "Game3", "Game4", "Game5"]
+  const gameExpLvl = ["Beginner", "Intermediate", "Advanced"]
+  const gaminghours = ["<100", "101-500", "501-1000", "1000+"]
   const [profilePic, setProfilePic] = useState<string | null>(null);
-  const [selectedPlatforms, setSelectedPlatforms] = useState<string[]>([]);
-  const [selectedPlayStyles, setSelectedPlayStyles] = useState<string[]>([]);
-  const [selectedGenres, setSelectedGenres] = useState<string[]>([]);
-
-
+  const [servers, setServers] = useState<string[]>([]);
+  const [games, setGames] = useState<string[]>([]);
+  const [experience, SetExperience] = useState<string[]>([]);
+  const [hours, setHours] = useState<string[]>([]);
+  const [error, setError] = useState<string>("");
 
   const [formData, setFormData] = useState({
     username: "",
-    favoriteGame: "",
-    platform: [],
-    playStyle: [],
-    genre: [],
+    servers: [],
+    games: [],
+    experience: [],
+    hours: [],
     about: "",
-    email: "myemail@example.com", // private, only user sees
   });
 
-  const togglePlatform = (platform : string) => {
-    setSelectedPlatforms((prev) => prev.includes(platform) ? 
-  prev.filter((p) => p !== platform) : [...prev, platform])
+  const toggleServer = (server : string) => {
+    setServers((prev) => prev.includes(server) ? 
+  prev.filter((p) => p !== server) : [...prev, server])
   }
 
-  const togglePlayStyle = (style : string) => {
-    setSelectedPlayStyles((prev) => prev.includes(style) ? 
-  prev.filter((p) => p !== style) : [...prev, style])
+  const toggleGameOption = (game : string) => {
+    setGames((prev) => prev.includes(game) ? 
+  prev.filter((p) => p !== game) : [...prev, game])
   }
 
-  const toggleGenres = (genre : string) => {
-    setSelectedGenres((prev) => prev.includes(genre) ? 
-  prev.filter((p) => p !== genre) : [...prev, genre])
+  const toggleLvl = (lvl : string) => {
+    SetExperience((prev) => prev.includes(lvl) ? 
+  prev.filter((p) => p !== lvl) : [...prev, lvl])
+  }
+
+  const toggleHours = (hours: string) => {
+    setHours((prev) => prev.includes(hours) ?
+  prev.filter((p) => p !== hours) : [...prev, hours])
   }
 
   const handleChange = (
@@ -63,10 +68,42 @@ const UserProfile: React.FC = () => {
     setProfilePic(null);
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    console.log("User Profile:", formData);
+
+    // Prepare the payload for api
+      const payload = {
+      username: formData.username,
+      servers: servers,
+      games: games,
+      experience: experience,
+      hours: hours,
+      about:formData.about
+    };
+
+    try {
+      const res = await fetch("http://localhost:8080/api/users/me/profile", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        //send cookies, JWT
+        credentials: "include", 
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        setError("Failed to save profile");
+      }
+
+      const data = await res.json();
+      console.log("Saved profile:", data);
+    } catch (err) {
+      setError("Failed to save profile")
+      console.error(err);
+    }
   };
+
 
   return (
     <div className="profile-card">
@@ -101,33 +138,53 @@ const UserProfile: React.FC = () => {
         </div>
 
         <div>
-          <div className="sector">Gaming Platform</div>
+          <div className="sector">Age</div>
+          <select></select>
+        </div>
+
+        <div>
+          <div className="sector">Preferred Servers</div>
           <div className="optionsmap">
-          {platformOptions.map(platform => <div key={platform} 
+          {serverOptions.map(server => <div key={server} 
               className={`options ${
-              selectedPlatforms.includes(platform) ? "selected" : ""
-            }`} > <div onClick={() => togglePlatform(platform)}>{platform} </div> </div>)}
+              servers.includes(server) ? "selected" : ""
+            }`} > <div onClick={() => toggleServer(server)}>{server} </div> </div>)}
           </div>
         </div>
 
         <div>
-          <div className="sector">Play Style</div>
+          <div className="sector">Games</div>
           <div className="optionsmap">
-          {playStyleOptions.map(style => <div key={style} 
+          {gameOptions.map(game => <div key={game} 
               className={`options ${
-              selectedPlayStyles.includes(style) ? "selected" : ""
-            }`} > <div onClick={() => togglePlayStyle(style)}>{style} </div> </div>)}
+              games.includes(game) ? "selected" : ""
+            }`} > <div onClick={() => toggleGameOption(game)}>{game} </div> </div>)}
           </div>
         </div>
 
         <div>
-          <div className="sector">Favorite Genre</div>
+          <div className="sector">Game Experience</div>
           <div className="optionsmap">
-          {genreOptions.map(genre => <div key={genre} 
+          {gameExpLvl.map(lvl => <div key={lvl} 
               className={`options ${
-              selectedGenres.includes(genre) ? "selected" : ""
-            }`} > <div onClick={() => toggleGenres(genre)}>{genre} </div> </div>)}
+              experience.includes(lvl) ? "selected" : ""
+            }`} > <div onClick={() => toggleLvl(lvl)}>{lvl} </div> </div>)}
           </div>
+        </div>
+
+        <div>
+          <div className="sector">Gaming hours</div>
+          <div className="optionsmap">
+          {gaminghours.map(hour => <div key={hour} 
+              className={`options ${
+              hours.includes(hour) ? "selected" : ""
+            }`} > <div onClick={() => toggleHours(hour)}>{hour} </div> </div>)}
+          </div>
+        </div>
+
+        <div>
+          <div className="sector">Preferred age</div>
+            <select></select>
         </div>
 
         <div>
@@ -149,7 +206,7 @@ const UserProfile: React.FC = () => {
           Save Profile
         </button>
       </form>
-
+      <div>{error}</div>
     </div>
   );
 };


### PR DESCRIPTION
1) Please check AuthController.java ->  cookie setup (@PostMapping("/login")) and send to front end via api when logging in. If its okay, then we can keep it, if you want to change/add/remove, please feel free to do it. If we add it to header, the only option is to save it to localstorage. If its sent as cookie, then its saved to cookies automatically. After that, every API call front end makes adds cookie with it to check if its valid.

2) JwtAuthenticationFilter.java -> If we send JWT and save it to cookie, then front end adds all cookies when making API call. A example in front end page userprofile.tsx:
      const res = await fetch("http://localhost:8080/api/users/me/profile", {
        method: "PUT",
        headers: {
          "Content-Type": "application/json",
        },
        //send cookies, JWT
        credentials: "include", 
        body: JSON.stringify(payload),
      });

3) Right now users can choose “gaming hours” to filter matches in future, but they can’t set their own gaming hours in their profile. This doesn’t make sense because the system can’t match them properly without knowing their own hours. Letting users enter their gaming hours would be an option?
